### PR TITLE
Add CloudBuild for CICD as demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ distributed as the public container image (`gcr.io/cloudrun/hello`) used in the
 the suggested container image  in the Cloud Run UI on Cloud Console.
 
 [![Run on Google Cloud](https://storage.googleapis.com/cloudrun/button.svg)](https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/cloud-run-hello.git)
+
+
+[Add a Cloud Build trigger](https://cloud.google.com/cloud-build/docs/running-builds/automate-builds) for the github repository, with Cloud Build configuration file location set to "/cloudbuild.yaml". The tigger watches any commit from any branch within the repository, then build & deploy to Cloud Run accordingly. 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+- id: 'Build Image'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ["build", "-t", "gcr.io/${PROJECT_ID}/hello:${SHORT_SHA}", "."]
+- id: 'Push Image'
+  name: 'gcr.io/cloud-builders/docker'
+  args: ["push", "gcr.io/${PROJECT_ID}/hello:${SHORT_SHA}"]
+- id: 'Deploy to Cloud Run'
+  name: 'gcr.io/cloud-builders/gcloud'
+  args: ['beta', 'run', 'deploy', 'hello', '--image', 'gcr.io/${PROJECT_ID}/hello:${SHORT_SHA}', '--allow-unauthenticated', '--region', 'us-central1','--platform', 'managed']
+images:
+- "gcr.io/${PROJECT_ID}/hello:${SHORT_SHA}"


### PR DESCRIPTION
- Added cloudbuild.yaml
- Added the instruction to add Cloud Build Trigger for a github repo.
- Deployed it and verified in a GCP account's Cloud Run