### PR TITLE
Change <h2> element to <div> element.

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ h1 {
 	margin-bottom: 0px;
 }
 
-h2 {
+.congrats {
 	font-size: 18px;
 	font-weight: normal;
 	margin-top: 4px;
@@ -146,7 +146,7 @@ code {
 
 			<div class="message">
 				<h1>It's running!</h1>
-				<h2>Congratulations, you successfully deployed a container image to Cloud Run</h2>
+				<div class="congrats">Congratulations, you successfully deployed a container image to Cloud Run</div>
 			</div>
 		</div>
 


### PR DESCRIPTION
Change `<h2>` element to `<div>` element, and add class to maintain the css style. Reason for this change is a failure in VPAT results:
```
GCR-3 Headings not correctly identified in markup
 - "Congratulations, you successfully deployed a container image to Cloud Run" is marked up as heading, although it is body text and not semantically a section heading.
```