### PR TITLE
Add 'View on Cloud Console' button as CTA

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -25,10 +25,10 @@ import (
 )
 
 type Data struct {
-	Service      string
-	Revision     string
-	Project      string
-	Region       string
+	Service  string
+	Revision string
+	Project  string
+	Region   string
 }
 
 func main() {
@@ -71,10 +71,10 @@ func main() {
 	revision := os.Getenv("K_REVISION")
 
 	data := Data{
-		Service:      service,
-		Revision:     revision,
-		Project:      project,
-		Region:       region,
+		Service:  service,
+		Revision: revision,
+		Project:  project,
+		Region:   region,
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ h3 {
 	max-width: 700px;
 	margin-left: auto;
 	margin-right: auto;
-} 
+}
 
 .hero {
 	margin-top: 172px;
@@ -93,9 +93,9 @@ code {
 }
 
 .cta a {
-	color: white;
+	background-color:rgba(233, 233, 233, 0.9);
+	color: rgb(14, 14, 14);
 	text-decoration: none;
-	background-color: rgb(14, 101, 241);
 	padding: 8px 12px;
 	margin-top: 8px;
 	margin-right: 4px;
@@ -105,6 +105,15 @@ code {
 }
 
 .cta a:hover {
+	background-color:rgba(213, 213, 213, 0.9);
+}
+
+.cta a.primary {
+	color: white;
+	background-color: rgb(14, 101, 241);
+}
+
+.cta a.primary:hover {
     background-color: rgb(66, 133, 244, 0.9);
 }
 
@@ -175,7 +184,7 @@ code {
 				language into
 				a container image, and then deploy it to Cloud Run.</p>
 			<p class="cta">
-				<a href="https://cloud.google.com/run/docs/quickstarts/build-and-deploy" target="_blank" rel="noopener">
+				<a class="primary" href="https://cloud.google.com/run/docs/quickstarts/build-and-deploy" target="_blank" rel="noopener">
 					BUILD AND DEPLOY QUICKSTART</a>
 				{{ if and .Project (and .Region .Service)  }}
 				<a href="https://console.cloud.google.com/run/detail/{{.Region}}/{{.Service}}/metrics?project={{.Project}}" target="_blank" rel="noopener">

--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@ code {
 	background-color: rgb(14, 101, 241);
 	padding: 8px 12px;
 	margin-top: 8px;
+	margin-right: 4px;
 	min-height: 36px;
 	border-radius: 2px;
 	font-weight: 600;
@@ -152,10 +153,15 @@ code {
 
 		<div class="details">
 			<p>
-                This created the revision <code>{{.Revision}}</code> of the Cloud Run service <code>{{.Service}}</code>
-                {{if .Region}} in <code>{{.Region}}</code>{{end}}
-                {{if .Project}} in the GCP project <code>{{.Project}}</code>{{end}}.
-            </p>
+				{{ if and .Project (and .Region .Service)  }}
+					This created the revision <code>{{.Revision}}</code> of the Cloud Run service <code>{{.Service}}</code>
+					{{if .Region}} in <code>{{.Region}}</code>{{end}}
+					{{if .Project}} in the GCP project <code>{{.Project}}</code>{{end}}.
+				{{ else }}
+					This container <strong>does not</strong> seem to be running
+					on Cloud Run.
+				{{ end }}
+			</p>
 
 			<p class="callout">
 				You can deploy any container to Cloud Run that listens for HTTP requests on the port defined by the
@@ -170,7 +176,12 @@ code {
 				a container image, and then deploy it to Cloud Run.</p>
 			<p class="cta">
 				<a href="https://cloud.google.com/run/docs/quickstarts/build-and-deploy" target="_blank" rel="noopener">
-					BUILD AND DEPLOY QUICKSTART</a></p>
+					BUILD AND DEPLOY QUICKSTART</a>
+				{{ if and .Project (and .Region .Service)  }}
+				<a href="https://console.cloud.google.com/run/detail/{{.Region}}/{{.Service}}/metrics?project={{.Project}}" target="_blank" rel="noopener">
+					VIEW ON CLOUD CONSOLE</a>
+				{{ end }}
+			</p>
 		</div>
 	</div>
 </body>

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@ code {
 					BUILD AND DEPLOY QUICKSTART</a>
 				{{ if and .Project (and .Region .Service)  }}
 				<a href="https://console.cloud.google.com/run/detail/{{.Region}}/{{.Service}}/metrics?project={{.Project}}" target="_blank" rel="noopener">
-					VIEW ON CLOUD CONSOLE</a>
+					VIEW IN CLOUD CONSOLE</a>
 				{{ end }}
 			</p>
 		</div>


### PR DESCRIPTION
Constructed URL to send users to Cloud Console for
playing with the deployed application further.

Also added handling for when container is not running
on Cloud Run.

cc: @steren PTAL
cc: @code128 for design input