### PR TITLE
Add environment variable COLOR to set background color of index.html

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -36,6 +36,7 @@ type Data struct {
 	Project            string
 	Region             string
 	AuthenticatedEmail string
+	Color              string
 }
 
 func handleReceivedEvent(ctx context.Context, event cloudevents.Event) {
@@ -150,11 +151,14 @@ func main() {
 	service := os.Getenv("K_SERVICE")
 	revision := os.Getenv("K_REVISION")
 
+	color := os.Getenv("COLOR")
+
 	data := Data{
 		Service:  service,
 		Revision: revision,
 		Project:  project,
 		Region:   region,
+		Color:    color,
 	}
 
 	eventsHandler := getEventsHandler()

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
  body {
 	font-family: 'Roboto', sans-serif;
 	font-display: fallback;
-	{{ if and .Color  }}
+	{{ if .Color  }}
 	background-color: {{ .Color  }};
 	{{ else }}
 	background: url('/assets/cloud_bg.svg');

--- a/index.html
+++ b/index.html
@@ -14,7 +14,11 @@
  body {
 	font-family: 'Roboto', sans-serif;
 	font-display: fallback;
+	{{ if and .Color  }}
+	background-color: {{ .Color  }};
+	{{ else }}
 	background: url('/assets/cloud_bg.svg');
+	{{ end }}
 	background-size: cover;
 	background-position: center;
 	line-height: 1.6;


### PR DESCRIPTION
Added environment variable COLOR to set, if present, the background color of index.html to address request in issue #28.

Examples:
```
gcloud run deploy cloud-run-hello --image <image> --set-env-vars COLOR=red --revision-suffix red --allow-unauthenticated

gcloud run deploy cloud-run-hello --image <image> --set-env-vars COLOR=#66FF99 --revision-suffix red --allow-unauthenticated
```