### PR TITLE
feat: Add job sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+.DS_Store

--- a/jobs/go.mod
+++ b/jobs/go.mod
@@ -1,0 +1,3 @@
+module github.com/googlecloudplatform/cloud-run-hello/jobs
+
+go 1.17

--- a/jobs/main.go
+++ b/jobs/main.go
@@ -1,0 +1,109 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+)
+
+type Config struct {
+	// Job-defined
+	taskNum    string
+	attemptNum string
+
+	// User-defined
+	sleepMs  int64
+	failRate float64
+}
+
+func configFromEnv() (Config, error) {
+	taskNum := os.Getenv("TASK_NUM")
+	attemptNum := os.Getenv("ATTEMPT_NUM")
+	sleepMs, err := sleepMsToInt(os.Getenv("SLEEP_MS"))
+	failRate, err := failRateToFloat(os.Getenv("FAIL_RATE"))
+
+	if err != nil {
+		return Config{}, err
+	}
+
+	config := Config{
+		taskNum:    taskNum,
+		attemptNum: attemptNum,
+		sleepMs:    sleepMs,
+		failRate:   failRate,
+	}
+	return config, nil
+}
+
+func sleepMsToInt(s string) (int64, error) {
+	sleepMs, err := strconv.ParseInt(s, 10, 64)
+	return sleepMs, err
+}
+
+func failRateToFloat(s string) (float64, error) {
+	// Default empty variable to 0
+	if s == "" {
+		return 0, nil
+	}
+
+	// Convert string to float
+	failRate, err := strconv.ParseFloat(s, 64)
+
+	// Check that rate is valid
+	if failRate < 0 || failRate > 1 {
+		return failRate, fmt.Errorf("Invalid FAIL_RATE value: %f. Must be a float between 0 and 1 inclusive.", failRate)
+	}
+
+	return failRate, err
+}
+
+func main() {
+	config, err := configFromEnv()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("Starting Task #%s, Attempt #%s ...", config.taskNum, config.attemptNum)
+
+	// Simulate work
+	if config.sleepMs > 0 {
+		time.Sleep(time.Duration(config.sleepMs) * time.Millisecond)
+	}
+
+	// Simulate errors
+	if config.failRate > 0 {
+		if failure := randomFailure(config); failure != nil {
+			log.Fatalf("%v", failure)
+		}
+	}
+
+	log.Printf("Completed Task #%s, Attempt #%s", config.taskNum, config.attemptNum)
+}
+
+// Throw an error based on fail rate
+func randomFailure(config Config) error {
+	rand.Seed(time.Now().UnixNano())
+	randomFailure := rand.Float64()
+
+	if randomFailure < config.failRate {
+		return fmt.Errorf("Task #%s, Attempt #%s failed.", config.taskNum, config.attemptNum)
+	}
+	return nil
+}

--- a/jobs/main_test.go
+++ b/jobs/main_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSuccessfulJob(t *testing.T) {
+	os.Setenv("SLEEP_MS", "0")
+	os.Setenv("TASK_NUM", "1")
+	os.Setenv("ATTEMPT_NUM", "1")
+	os.Unsetenv("FAIL_RATE")
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	main()
+	log.SetOutput(os.Stdout)
+	output := buf.String()
+
+	start := "Starting Task #1, Attempt #1 ..."
+	finish := "Completed Task #1, Attempt #1"
+
+	if !(strings.Contains(output, start)) {
+		t.Errorf("\nWant:\n%s\n\nGot:\n%s", start, output)
+	}
+
+	if !(strings.Contains(output, finish)) {
+		t.Errorf("\nWant:\n%s\n\nGot:\n%s", finish, output)
+	}
+}
+
+func TestRandomFailure(t *testing.T) {
+	config := Config{
+		taskNum:    "1",
+		attemptNum: "1",
+		sleepMs:    2,
+		failRate:   1,
+	}
+
+	err := randomFailure(config)
+	if err == nil {
+		t.Fatalf("Test should fail with FAIL_RATE 1")
+	}
+
+	config.failRate = 0
+	err = randomFailure(config)
+	if err != nil {
+		t.Fatalf("Test should pass with empty FAIL_RATE")
+	}
+}

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,39 @@
+# Testing for Cloud Run Samples
+
+A Google Cloud Project is required in order to run the tests in the Cloud Run Samples. The project should have the following API's enabled:
+
+* Cloud Run
+* Cloud Build
+* Container Registry
+
+## Test Project Setup
+
+* Set up billing for your project
+* Cloud Build must be given access to deploy Cloud Run services (see [Deploying to Cloud Run][access]).
+* Cloud Build GitHub App needs to be installed and connected to the repository. More info can be found in [Installing the Cloud Build app][app].
+
+## Cloud Build Triggers
+
+Each sample has Cloud Build triggers:
+
+* A **Pull Request trigger** which checks incoming changes.
+* A **Merge trigger** which builds and pushes new container images.
+* A **Nightly trigger** which checks the affects of product changes, environment changes, and flakiness.
+
+
+## Manually Start Cloud Builds
+
+To manually trigger a Cloud Run (fully managed) build via CLI:
+
+```sh
+export SAMPLE=jobs
+gcloud builds submit \
+  --config "testing/$SAMPLE.pr.cloudbuild.yaml" \
+  --substitutions "SHORT_SHA=manual,_SAMPLE_DIR=${SAMPLE}"
+```
+
+
+[folder]: https://cloud.google.com/sdk/gcloud/reference/projects/create#--folder
+[access]: https://cloud.google.com/cloud-build/docs/deploying-builds/deploy-cloud-run
+[app]: https://cloud.google.com/cloud-build/docs/automating-builds/create-github-app-triggers#installing_the_cloud_build_app
+[sub]: https://cloud.google.com/cloud-build/docs/configuring-builds/substitute-variable-values#using_user-defined_substitutions

--- a/testing/README.md
+++ b/testing/README.md
@@ -20,6 +20,11 @@ Each sample has Cloud Build triggers:
 * A **Merge trigger** which builds and pushes new container images.
 * A **Nightly trigger** which checks the affects of product changes, environment changes, and flakiness.
 
+The trigger configs are defined in `testing/triggers` and can be imported via:
+
+```sh
+gcloud beta builds triggers import --source=testing/triggers/jobs.<TYPE>.yaml
+```
 
 ## Manually Start Cloud Builds
 

--- a/testing/jobs.merge.cloudbuild.yaml
+++ b/testing/jobs.merge.cloudbuild.yaml
@@ -1,0 +1,38 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+
+- id: 'Build Container Image'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  dir: '${_SAMPLE_DIR}'
+  args: ['builds', 'submit', '--pack', 'image=gcr.io/${PROJECT_ID}/${_IMAGE}:latest']
+
+- id: 'Pull Container Image'
+  name: 'gcr.io/cloud-builders/docker:latest'
+  args: ['pull', 'gcr.io/${PROJECT_ID}/${_IMAGE}:latest']
+
+- id: 'Tag Container Image'
+  name: 'gcr.io/cloud-builders/docker:latest'
+  args: ['tag', 'gcr.io/${PROJECT_ID}/${_IMAGE}:latest', '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_IMAGE}:latest']
+
+- id: 'Push Container Image'
+  name: 'gcr.io/cloud-builders/docker:latest'
+  args: ['push', '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_IMAGE}:latest']
+
+substitutions:
+  _IMAGE: job
+  _LOCATION: us
+  _REPO: container
+  _CLOUDSDK_VERSION: latest

--- a/testing/jobs.nightly.cloudbuild.yaml
+++ b/testing/jobs.nightly.cloudbuild.yaml
@@ -1,0 +1,68 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+
+- id: 'Deploy to Cloud Run'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - |
+    gcloud components install alpha --quiet
+    
+    gcloud alpha run jobs create ${_IMAGE}-${BUILD_ID} \
+      --image gcr.io/${PROJECT_ID}/${_IMAGE}:latest \
+      --project ${PROJECT_ID} \
+      --region ${_REGION} \
+      --tasks 2 \
+      --set-env-vars=SLEEP_MS=1000 \
+      --max-retries 0 \
+      --wait
+
+- id: 'Integration Tests'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - |
+    output=$(gcloud logging read \
+      "resource.type=cloud_run_job \
+      AND resource.labels.job_name=${_IMAGE}-${BUILD_ID} \
+      AND resource.labels.location=${_REGION} \
+      AND Task #" \
+      --limit 10 --format 'value(textPayload)')
+    echo $output
+
+    if [[ $output ]]; then
+      echo "Logs Found."
+    else
+      exit 1
+    fi
+
+- id: 'Teardown'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    set -x
+    gcloud --quiet alpha run jobs delete ${_IMAGE}-${BUILD_ID} --region ${_REGION}
+    set +x
+
+substitutions:
+  _IMAGE: job
+  _LOCATION: us
+  _REPO: container
+  _CLOUDSDK_VERSION: latest

--- a/testing/jobs.pr.cloudbuild.yaml
+++ b/testing/jobs.pr.cloudbuild.yaml
@@ -1,0 +1,92 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+
+- id: 'Lint'
+  name: 'golang:1.18-alpine'
+  dir: '${_SAMPLE_DIR}'
+  entrypoint: /bin/sh
+  args: 
+  - '-c'
+  - |
+    go install golang.org/x/tools/cmd/goimports@latest
+    if [ -n "$(goimports -d .)" ]; then
+      echo 'To fix this check, run "goimports -w ."'
+      exit 1
+    fi
+
+- id: 'Unit Tests'
+  name: 'golang:1.18-alpine'
+  dir: '${_SAMPLE_DIR}'
+  args: ['test', '-v']
+
+- id: 'Build Container Image'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  dir: '${_SAMPLE_DIR}'
+  args: ['builds', 'submit', '--pack', 'image=gcr.io/${PROJECT_ID}/${_IMAGE}:${SHORT_SHA}'] # Tag docker image with git commit sha
+
+- id: 'Deploy to Cloud Run'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - |
+    gcloud components install alpha --quiet
+    
+    gcloud alpha run jobs create ${_IMAGE}-${SHORT_SHA} \
+      --image gcr.io/${PROJECT_ID}/${_IMAGE}:${SHORT_SHA} \
+      --project ${PROJECT_ID} \
+      --region ${_REGION} \
+      --tasks 2 \
+      --set-env-vars=SLEEP_MS=1000 \
+      --max-retries 0 \
+      --wait
+
+- id: 'Integration Tests'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - |
+    output=$(gcloud logging read \
+      "resource.type=cloud_run_job \
+      AND resource.labels.job_name=${_IMAGE}-${SHORT_SHA} \
+      AND resource.labels.location=${_REGION} \
+      AND Task #" \
+      --limit 10 --format 'value(textPayload)')
+    echo $output
+
+    if [[ $output ]]; then
+      echo "Logs Found."
+    else
+      exit 1
+    fi
+
+- id: 'Teardown'
+  name: 'gcr.io/cloud-builders/gcloud:$_CLOUDSDK_VERSION'
+  entrypoint: '/bin/bash'
+  args:
+  - '-c'
+  - |
+    set -x
+    gcloud --quiet container images delete gcr.io/${PROJECT_ID}/${_IMAGE}:${SHORT_SHA} --force-delete-tags
+    gcloud --quiet alpha run jobs delete ${_IMAGE}-${SHORT_SHA} --region ${_REGION}
+    set +x
+
+substitutions:
+  _IMAGE: job-pr
+  _SAMPLE_DIR: jobs
+  _REGION: us-central1
+  _CLOUDSDK_VERSION: latest

--- a/testing/triggers/jobs.merge.yaml
+++ b/testing/triggers/jobs.merge.yaml
@@ -1,0 +1,9 @@
+name: jobs-merge
+filename: testing/jobs.merge.cloudbuild.yaml
+github:
+  name: cloud-run-hello
+  owner: GoogleCloudPlatform
+  push:
+    branch: ^master$
+includedFiles:
+- jobs/**

--- a/testing/triggers/jobs.nightly.yaml
+++ b/testing/triggers/jobs.nightly.yaml
@@ -1,0 +1,10 @@
+name: jobs-nightly
+gitFileSource:
+  path: testing/jobs.nightly.cloudbuild.yaml
+  repoType: GITHUB
+  revision: refs/heads/master
+  uri: https://github.com/GoogleCloudPlatform/cloud-run-hello
+sourceToBuild:
+  ref: refs/heads/master
+  repoType: GITHUB
+  uri: https://github.com/GoogleCloudPlatform/cloud-run-hello

--- a/testing/triggers/jobs.pr.yaml
+++ b/testing/triggers/jobs.pr.yaml
@@ -1,0 +1,11 @@
+name: jobs-pr
+description: "Build and deploy a test job"
+filename: testing/jobs.pr.cloudbuild.yaml
+github:
+  name: cloud-run-hello
+  owner: GoogleCloudPlatform
+  pullRequest:
+    branch: ^master$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+includedFiles:
+- jobs/**


### PR DESCRIPTION
This is the same sample as https://github.com/GoogleCloudPlatform/golang-samples/tree/main/run/jobs

This PR also defines Cloud Build configs and triggers to run on PRs, Merges (to master), and Nightly.
* On PR: Lint, Build, deploy to test environment, and test deployment
  * On failure - block PR (setting will be added)
* On Merge: Build and push image to GCR and AR (with latest tag)
  * On failure - file GitHub issue (notifier will be added)
*On Nightly Schedule: Deploy image and test
  * On failure - file GitHub issue (notifier will be added)

Any needed changes to services will be added in a separate PR. Should the service code be at root level or in a service directory?