### PR TITLE
Use ENTRYPOINT instead of CMD

### DIFF
--- a/placeholder.dockerfile
+++ b/placeholder.dockerfile
@@ -30,4 +30,4 @@ COPY placeholder.html ./index.html
 COPY assets/ ./assets/
 
 # Run the web service on container startup.
-CMD ["/server"]
+ENTRYPOINT ["/server"]


### PR DESCRIPTION
This lets us use this placeholder interchangeably with our real container images, since the placeholder ignores its arguments. (With CMD, the arguments replaced the command instead of being passed to the command.)

Fixes #54