### PR TITLE
feat: Block major crawlers

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -173,6 +173,10 @@ func main() {
 		tmpl.Execute(w, data)
 	})
 
+	http.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "User-agent: *\nDisallow: /\n")
+	})
+
 	fs := http.FileServer(http.Dir("./assets"))
 	http.Handle("/assets/", http.StripPrefix("/assets/", fs))
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset=utf-8>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
 <title>Congratulations | Cloud Run</title>
 <link href="https://fonts.googleapis.com/css?family=Roboto" rel="preload" as="font">
 <link


### PR DESCRIPTION
I don't think [indexing 'hello world' apps](https://www.google.com/search?q=%22congratulations%2C+you+successfully+deployed+a+container+image+to+cloud+run%22) is necessary. How about adding robot.txt in order to reduce the risks.
