### PR TITLE
Use FROM scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,32 +2,31 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.20.5 as builder
-
 # Create and change to the app directory.
 WORKDIR /app
-
 # Retrieve application dependencies using go modules.
 # Allows container builds to reuse downloaded dependencies.
 COPY go.* ./
 RUN go mod download
-
 # Copy local code to the container image.
 COPY . ./
-
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 
-# Use the official Alpine image for a lean production container.
+# Use the official Alpine image to get the standard for a lean production container.
 # https://hub.docker.com/_/alpine
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3
+FROM alpine:3 AS certs 
 RUN apk add --no-cache ca-certificates
 
+# Build the runtime container image from scratch, copying what is needed from the two previous stages.  
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM scratch
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/server /server
 COPY index.html ./index.html
 COPY assets/ ./assets/
-
+# Copy the root certificates from the certs stage
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # Run the web service on container startup.
-CMD ["/server"]
+ENTRYPOINT ["/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . ./
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 
-# Use the official Alpine image to get the standard for a lean production container.
+# Use the official Alpine image to install certificates.
 # https://hub.docker.com/_/alpine
 FROM alpine:3 AS certs 
 RUN apk add --no-cache ca-certificates

--- a/placeholder.dockerfile
+++ b/placeholder.dockerfile
@@ -14,7 +14,7 @@ COPY . ./
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 
-# Use the official Alpine image to get the standard for a lean production container.
+# Use the official Alpine image to install certificates.
 # https://hub.docker.com/_/alpine
 FROM alpine:3 AS certs 
 RUN apk add --no-cache ca-certificates

--- a/placeholder.dockerfile
+++ b/placeholder.dockerfile
@@ -2,32 +2,31 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.20.5 as builder
-
 # Create and change to the app directory.
 WORKDIR /app
-
 # Retrieve application dependencies using go modules.
 # Allows container builds to reuse downloaded dependencies.
 COPY go.* ./
 RUN go mod download
-
 # Copy local code to the container image.
 COPY . ./
-
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
 RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 
-# Use the official Alpine image for a lean production container.
+# Use the official Alpine image to get the standard for a lean production container.
 # https://hub.docker.com/_/alpine
-# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3
+FROM alpine:3 AS certs 
 RUN apk add --no-cache ca-certificates
 
+# Build the runtime container image from scratch, copying what is needed from the two previous stages.  
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM scratch
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/server /server
 COPY placeholder.html ./index.html
 COPY assets/ ./assets/
-
+# Copy the root certificates from the certs stage
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # Run the web service on container startup.
 ENTRYPOINT ["/server"]


### PR DESCRIPTION
Leverage a multi-stage build in order to install certs and then copy them to the scratch image

Tested locally and deployed to Cloud Run: https://hello-scratch-n2k6p2rf7a-od.a.run.app/