### PR TITLE
feat: add info endpoint for data as json format

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -173,6 +173,13 @@ func main() {
 		tmpl.Execute(w, data)
 	})
 
+	http.HandleFunc("/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		encoder.Encode(data)
+	})
+
 	http.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "User-agent: *\nDisallow: /\n")
 	})


### PR DESCRIPTION
### Problem Statement

Current implementation mainly targets an HTML based UI demo.

In my experience this makes the following use cases less elegant to demo:

1.  Authentication with just a simple cURL command
2. Show load balancing distribution e.g. based  on the color value in an automated capture.
3. Call a service from a bastion host that can't show the rendered HTML page

### Proposal

Add `/info` endpoint that directly outputs the existing data struct without the HTML template.

### Demo

Service

```sh
K_SERVICE=foo K_REVISION=bar COLOR=my-color go run hello.go
```

Client 

```sh
curl localhost:8080/info
```

response
                
```json                       
{
  "Service": "foo",
  "Revision": "bar",
  "Project": "my-host",
  "Region": "europe-west1-d",
  "AuthenticatedEmail": "",
  "Color": "my-color"
}
```