### PR TITLE
Revert: asset path

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -97,7 +97,7 @@ func getEventsHandler() *cloudeventsClient.EventReceiver {
 }
 
 func main() {
-	tmpl := template.Must(template.ParseFiles("/index.html"))
+	tmpl := template.Must(template.ParseFiles("index.html"))
 
 	// Get project ID from metadata server
 	project := ""

--- a/hello.go
+++ b/hello.go
@@ -177,7 +177,7 @@ func main() {
 		fmt.Fprintf(w, "User-agent: *\nDisallow: /\n")
 	})
 
-	fs := http.FileServer(http.Dir("/assets"))
+	fs := http.FileServer(http.Dir("./assets"))
 	http.Handle("/assets/", http.StripPrefix("/assets/", fs))
 
 	port := os.Getenv("PORT")


### PR DESCRIPTION
Fixes #98

- Revert "read index.html using absolute path (#96)"
- Revert "read assets/ using absolute path (#97)"

I could confirm this code (after revert) works correctly:

- locally

```
% go run . 
```

- in Docker:

```
docker build -t cloud-run-hello-fix98 .
docker run -ePORT=8080 -p8080:8080 cloud-run-hello-fix98
```