### PR TITLE
Set workdir to /workspace

### DIFF
--- a/hello.go
+++ b/hello.go
@@ -97,7 +97,7 @@ func getEventsHandler() *cloudeventsClient.EventReceiver {
 }
 
 func main() {
-	tmpl := template.Must(template.ParseFiles("/index.html"))
+	tmpl := template.Must(template.ParseFiles("./index.html"))
 
 	// Get project ID from metadata server
 	project := ""
@@ -177,7 +177,7 @@ func main() {
 		fmt.Fprintf(w, "User-agent: *\nDisallow: /\n")
 	})
 
-	fs := http.FileServer(http.Dir("/assets"))
+	fs := http.FileServer(http.Dir("./assets"))
 	http.Handle("/assets/", http.StripPrefix("/assets/", fs))
 
 	port := os.Getenv("PORT")

--- a/placeholder.dockerfile
+++ b/placeholder.dockerfile
@@ -22,6 +22,8 @@ RUN apk add --no-cache ca-certificates
 # Build the runtime container image from scratch, copying what is needed from the two previous stages.  
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM scratch
+# Create and change to the workspace directory.
+WORKDIR /workspace
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/server /server
 COPY placeholder.html ./index.html


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-run-hello/issues/98

Revert "read index.html using absolute path (https://github.com/GoogleCloudPlatform/cloud-run-hello/pull/96)"
Revert "read assets/ using absolute path (https://github.com/GoogleCloudPlatform/cloud-run-hello/pull/97)"
Set workdir of placeholder image to "/workspace"

Validated the following use cases worked:
- `go run .`
- `docker build ...; docker run ...`
- Cloud Run deployment of built placeholder image with ABIU (need to set workdir to /workspace for accessing files using relative paths)
- Cloud Run deployment of built placeholder image without ABIU