### PR TITLE
Set workdir to /workspace in the main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 # Build the runtime container image from scratch, copying what is needed from the previous stage.  
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM scratch
+# Create and change to the workspace directory.
+WORKDIR /workspace
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/server /server
 COPY index.html ./index.html


### PR DESCRIPTION
Similar to https://github.com/GoogleCloudPlatform/cloud-run-hello/pull/102

With this change the image still work standalone, but also if used with a base image.