### PR TITLE
fix: docker build warns on capitalization mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 # Create and change to the app directory.
 WORKDIR /app
 # Retrieve application dependencies using go modules.

--- a/placeholder.dockerfile
+++ b/placeholder.dockerfile
@@ -1,7 +1,7 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23 as builder
+FROM golang:1.23 AS builder
 # Create and change to the app directory.
 WORKDIR /app
 # Retrieve application dependencies using go modules.


### PR DESCRIPTION
Confirmed local build works without warning.