### PR TITLE
ci: add release workflow to publish image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+  name: Release to GHCR
+  
+  on:
+    push:
+      branches:
+        - main
+  
+  env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{ github.repository }}
+  
+  jobs:
+    build-and-push-image:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        packages: write
+  
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3
+  
+        - name: Log in to the Container registry
+          uses: docker/login-action@v2
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+  
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: docker/metadata-action@v4
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            tags: |
+              type=raw,value=latest
+  
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v4
+          with:
+            context: .
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
   on:
     push:
       branches:
-        - main
+        - master
   
   env:
     REGISTRY: ghcr.io
@@ -18,7 +18,7 @@
   
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v3
+          uses: actions/checkout@v6
   
         - name: Log in to the Container registry
           uses: docker/login-action@v2


### PR DESCRIPTION
add GitHub Actions workflow to automatically build and release image to ghcr.io
