### PR TITLE
Add ability to return text and json responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ A sample service implemented in Go and distributed as a public container image. 
 
 Set the `COLOR` environment variable to a valid CSS color to change the background color.
 
+### Response Formats
+
+By default, the service returns answers in HTML format. You can also request responses in JSON or plain text format by passing a URL query parameter or an HTTP header:
+
+* **URL Query Parameter:** Add `?format=json`, `?format=text` (or `plain`), or `?format=html`.
+* **Custom Headers:** Pass `Format: json` or `X-Format: json` (and `text` / `html`).
+* **Standard Header:** Pass `Accept: application/json`, `Accept: text/plain`, or `Accept: text/html`.
+
 <a href="https://deploy.cloud.run"><img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud" height="40"/></a>
 
 ## Hello job

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A sample service implemented in Go and distributed as a public container image. 
 
 * **Container Image:** `us-docker.pkg.dev/cloudrun/container/hello`
 
+<a href="https://deploy.cloud.run"><img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud" height="40"/></a>
+
 ### Configuration Options
 
 Set the `COLOR` environment variable to a valid CSS color to change the background color.
@@ -18,8 +20,6 @@ By default, the service returns answers in HTML format. You can also request res
 
 * **URL Query Parameter:** Add `?format=json`, `?format=text` (or `plain`), or `?format=html`.
 * **Standard Header:** Pass `Accept: application/json`, `Accept: text/plain`, or `Accept: text/html`.
-
-<a href="https://deploy.cloud.run"><img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud" height="40"/></a>
 
 ## Hello job
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Set the `COLOR` environment variable to a valid CSS color to change the backgrou
 By default, the service returns answers in HTML format. You can also request responses in JSON or plain text format by passing a URL query parameter or an HTTP header:
 
 * **URL Query Parameter:** Add `?format=json`, `?format=text` (or `plain`), or `?format=html`.
-* **Custom Headers:** Pass `Format: json` or `X-Format: json` (and `text` / `html`).
 * **Standard Header:** Pass `Accept: application/json`, `Accept: text/plain`, or `Accept: text/html`.
 
 <a href="https://deploy.cloud.run"><img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud" height="40"/></a>

--- a/hello.go
+++ b/hello.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019-2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,18 +25,19 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cloudeventsClient "github.com/cloudevents/sdk-go/v2/client"
 )
 
 type Data struct {
-	Service            string
-	Revision           string
-	Project            string
-	Region             string
-	AuthenticatedEmail string
-	Color              string
+	Service            string `json:"service"`
+	Revision           string `json:"revision"`
+	Project            string `json:"project"`
+	Region             string `json:"region"`
+	AuthenticatedEmail string `json:"authenticatedEmail,omitempty"`
+	Color              string `json:"color,omitempty"`
 }
 
 func handleReceivedEvent(ctx context.Context, event cloudevents.Event) {
@@ -94,6 +95,47 @@ func getEventsHandler() *cloudeventsClient.EventReceiver {
 		log.Fatalf("failed to create handler for receiving events: %s", err.Error())
 	}
 	return h
+}
+
+func determineFormat(r *http.Request) string {
+	// 1. Check query parameter e.g. ?format=json, ?format=text, ?format=html
+	fmtParam := strings.ToLower(r.URL.Query().Get("format"))
+	switch fmtParam {
+	case "json":
+		return "json"
+	case "text", "plain":
+		return "text"
+	case "html":
+		return "html"
+	}
+
+	// 2. Check custom headers e.g. Format: json or X-Format: json
+	for _, h := range []string{"Format", "X-Format"} {
+		val := strings.ToLower(r.Header.Get(h))
+		switch val {
+		case "json":
+			return "json"
+		case "text", "plain":
+			return "text"
+		case "html":
+			return "html"
+		}
+	}
+
+	// 3. Check Accept header
+	accept := strings.ToLower(r.Header.Get("Accept"))
+	if strings.Contains(accept, "application/json") {
+		return "json"
+	}
+	if strings.Contains(accept, "text/plain") {
+		return "text"
+	}
+	if strings.Contains(accept, "text/html") {
+		return "html"
+	}
+
+	// Default to html
+	return "html"
 }
 
 func main() {
@@ -170,7 +212,23 @@ func main() {
 		}
 		// Default handler (hello page).
 		data.AuthenticatedEmail = r.Header.Get("X-Goog-Authenticated-User-Email") // set when behind IAP
-		tmpl.Execute(w, data)
+		switch determineFormat(r) {
+		case "json":
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			json.NewEncoder(w).Encode(data)
+		case "text":
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			fmt.Fprintf(w, "Service: %s\nRevision: %s\nProject: %s\nRegion: %s\n", data.Service, data.Revision, data.Project, data.Region)
+			if data.AuthenticatedEmail != "" {
+				fmt.Fprintf(w, "AuthenticatedEmail: %s\n", data.AuthenticatedEmail)
+			}
+			if data.Color != "" {
+				fmt.Fprintf(w, "Color: %s\n", data.Color)
+			}
+		default:
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			tmpl.Execute(w, data)
+		}
 	})
 
 	http.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {

--- a/hello.go
+++ b/hello.go
@@ -98,7 +98,7 @@ func getEventsHandler() *cloudeventsClient.EventReceiver {
 }
 
 func determineFormat(r *http.Request) string {
-	// 1. Check query parameter e.g. ?format=json, ?format=text, ?format=html
+	// Check query parameter e.g. ?format=json, ?format=text, ?format=html
 	fmtParam := strings.ToLower(r.URL.Query().Get("format"))
 	switch fmtParam {
 	case "json":
@@ -109,20 +109,7 @@ func determineFormat(r *http.Request) string {
 		return "html"
 	}
 
-	// 2. Check custom headers e.g. Format: json or X-Format: json
-	for _, h := range []string{"Format", "X-Format"} {
-		val := strings.ToLower(r.Header.Get(h))
-		switch val {
-		case "json":
-			return "json"
-		case "text", "plain":
-			return "text"
-		case "html":
-			return "html"
-		}
-	}
-
-	// 3. Check Accept header
+	// Check Accept header
 	accept := strings.ToLower(r.Header.Get("Accept"))
 	if strings.Contains(accept, "application/json") {
 		return "json"


### PR DESCRIPTION
It allows the service to return replies in json and text format by passing a url parameter, or a standard/custom header.